### PR TITLE
Update google-generativeai to latest version (0.8.5)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ telethon
 flask-jwt-extended
 openai
 requests
-google-generativeai
+google-generativeai==0.8.5
 Flask-SQLAlchemy>=2.5.0
 flask-caching
 google-auth-oauthlib


### PR DESCRIPTION
Updated to google-generativeai==0.8.5 (latest stable version as of Oct 2025) to fix API compatibility issues with Gemini 2.0 Flash.

Fixes AttributeError: whichOneof error that prevented menu generation.

Note: google-generativeai is legacy SDK (support ends Aug 2025). Future migration to google-genai SDK may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)