### PR TITLE
תיקון בעיית מחיקת מתכונים מועדפים מיידית

### DIFF
--- a/frontend/ourRecipesFront/src/app/(main)/page.tsx
+++ b/frontend/ourRecipesFront/src/app/(main)/page.tsx
@@ -103,12 +103,6 @@ export default function Page() {
                 errorData: error?.data,
                 fullError: JSON.stringify(error, Object.getOwnPropertyNames(error))
               });
-
-              // Only remove from favorites if confirmed 404
-              if (error?.status === 404) {
-                console.warn(`⚠️ Recipe ${id} not found (404) - removing from favorites`);
-                setFavorites(prev => prev.filter(favId => favId !== id));
-              }
               return null;
             })
         );
@@ -135,7 +129,7 @@ export default function Page() {
     };
 
     fetchFavoriteRecipes();
-  }, [favorites, setFavorites]);
+  }, [favorites]); // setFavorites removed - it's stable and doesn't need to be in dependencies
 
   if (isLoading) {
     return (

--- a/frontend/ourRecipesFront/src/services/apiService.ts
+++ b/frontend/ourRecipesFront/src/services/apiService.ts
@@ -2,6 +2,11 @@ import { authService } from './authService';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
+// Log API URL on initialization (only in browser, not during SSR)
+if (typeof window !== 'undefined') {
+  console.log('🔧 API Service initialized with URL:', API_URL || '[NOT SET]');
+}
+
 // Custom error class for API errors
 export class ApiError extends Error {
   constructor(


### PR DESCRIPTION
הבעיה:
- כאשר משתמש מוסיף מתכון למועדפים, ה-useEffect היה מנסה לשלוף אותו
- אם היה שגיאה, הקוד היה מסיר את המתכון אוטומטית
- זה גרם למתכונים להימחק מיד לאחר ההוספה

התיקון:
- הסרת setFavorites מ-dependencies של useEffect (setter יציב, לא צריך להיות שם)
- הסרת המחיקה האוטומטית של מתכונים עם שגיאות
- הוספת לוג API_URL לאבחון
- השארת הלוגים המפורטים לאבחון הבעיה האמיתית

כעת המתכונים לא יימחקו אוטומטית והלוגים יעזרו לזהות את הבעיה