### PR TITLE
Fix favorite recipes feature implementation

### DIFF
--- a/frontend/ourRecipesFront/src/app/(main)/page.tsx
+++ b/frontend/ourRecipesFront/src/app/(main)/page.tsx
@@ -64,7 +64,7 @@ export default function Page() {
       setFavoritesError(null);
 
       if (favorites.length === 0) {
-        console.log('✅ No favorites found in localStorage');
+        console.log('✅ No favorites found');
         setFavoriteRecipes([]);
         setIsLoadingFavorites(false);
         return;
@@ -147,7 +147,7 @@ export default function Page() {
     };
 
     fetchFavoriteRecipes();
-  }, [favorites]); // setFavorites removed - it's stable and doesn't need to be in dependencies
+  }, [favorites, setFavorites]); // setFavorites is stable from context
 
   if (isLoading) {
     return (


### PR DESCRIPTION
הבעיה:
- מתכונים מועדפים נמחקו בכל כניסה לאפליקציה
- הבעיה נגרמה מ-SSR של Next.js שאתחל את state כמערך ריק
- useEffect שמר את המערך הריק ל-localStorage לפני טעינת הערכים האמיתיים

הפתרון:
1. FavoritesContext.tsx:
   - הפרדה בין טעינה משמירה ב-localStorage
   - שימוש ב-isInitialized flag למניעת שמירה לפני טעינה
   - טעינה מ-localStorage ב-useEffect נפרד שרץ פעם אחת
   - שמירה רק אחרי שסיימנו לטעון מ-localStorage

2. page.tsx:
   - הוספת setFavorites ל-dependencies של useEffect
   - שיפור הלוגיקה של ניקוי IDs לא תקפים

קבצים שהשתנו:
- frontend/ourRecipesFront/src/contexts/FavoritesContext.tsx
- frontend/ourRecipesFront/src/app/(main)/page.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors favorites to initialize from localStorage in an effect with an initialization guard, and updates page favorites effect dependencies.
> 
> - **FavoritesContext (`frontend/ourRecipesFront/src/contexts/FavoritesContext.tsx`)**:
>   - Initialize `favorites` empty and load from `localStorage` in a one-time `useEffect`.
>   - Add `isInitialized` flag to prevent syncing before initial load.
>   - Sync to `localStorage` only after initialization (`useEffect` on `[favorites, isInitialized]`).
>   - Preserve `setFavorites` wrapper and existing API.
> - **Main Page (`frontend/ourRecipesFront/src/app/(main)/page.tsx`)**:
>   - Update favorites fetching effect dependencies to `[favorites, setFavorites]`.
>   - Minor log message tweak for empty favorites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 967187024627458201ec419b6c3d356b1e3a774d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->