### PR TITLE
הוספת תמיכה ב-API Key נפרד לNano Banana Pro

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,7 @@ ENV_FILE_ID="your_env_file_id"  # ID of the .env file in Google Drive
 # API Keys
 OPENAI_API_KEY="sk-..."  # Your OpenAI API key
 HF_TOKEN="Bearer hf_..."  # HuggingFace API token
+GOOGLE_API_KEY_NANO_BANANA="your_paid_gemini_api_key"  # Paid Google API key for Nano Banana Pro (gemini-3-pro-image-preview)
 
 # CORS & Server Configuration
 ORIGIN_CORS="http://localhost:3000"  # Frontend URL for CORS (development)

--- a/backend/ourRecipesBack/config.py
+++ b/backend/ourRecipesBack/config.py
@@ -79,6 +79,7 @@ class Config:
 
     # AI Service settings
     GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+    GOOGLE_API_KEY_NANO_BANANA = os.getenv("GOOGLE_API_KEY_NANO_BANANA")  # Paid API key for Nano Banana Pro
     HF_TOKEN = os.getenv("HF_TOKEN")
 
     # google drive settings

--- a/backend/ourRecipesBack/services/ai_service.py
+++ b/backend/ourRecipesBack/services/ai_service.py
@@ -269,8 +269,9 @@ class AIService:
             str: Base64 encoded image
         """
         try:
-            # Create AI client
-            client = genai.Client(api_key=current_app.config["GOOGLE_API_KEY"])
+            # Create AI client with Nano Banana Pro API key (paid account)
+            api_key = current_app.config.get("GOOGLE_API_KEY_NANO_BANANA") or current_app.config["GOOGLE_API_KEY"]
+            client = genai.Client(api_key=api_key)
 
             # Create a detailed Hebrew prompt for infographic generation
             prompt_text = f"""


### PR DESCRIPTION
שינויים:
- הוספת GOOGLE_API_KEY_NANO_BANANA למשתנה סביבה חדש
- עדכון ai_service.py להשתמש ב-API key בתשלום לפונקציית האינפוגרפיקה
- fallback ל-GOOGLE_API_KEY אם NANO_BANANA לא מוגדר
- עדכון config.py להטעין את המשתנה החדש
- עדכון .env.example עם הדוקומנטציה

זה מאפשר להשתמש ב-gemini-3-pro-image-preview עם חשבון בתשלום בעוד ששאר הפונקציות משתמשות ב-API key החינמי